### PR TITLE
BEP036 IndexColumns rewrite draft

### DIFF
--- a/src/appendices/phenotype.md
+++ b/src/appendices/phenotype.md
@@ -176,10 +176,10 @@ Contents of `phenotype/tool-Measurements_phenotype.json`
         "session_id"
     ],
     "participant_id": {
-        "Description": "BIDS participant identifier"
+        "Description": "Participant identifier"
     },
     "session_id": {
-        "Description": "BIDS session identifier",
+        "Description": "Session identifier",
         "Levels": {
             "ses-pheno": "Phenotype-only session",
             "ses-MRI": "MRI-only session"
@@ -359,10 +359,10 @@ and how `"IndexColumns"` is present.
         "session_id"
     ],
     "participant_id": {
-        "Description": "BIDS participant identifier"
+        "Description": "Participant identifier"
     },
     "session_id": {
-        "Description": "BIDS session identifier",
+        "Description": "Session identifier",
         "Levels": {
             "ses-baseline": "Baseline visit for MRI and assessments",
             "ses-followupMRI": "6-months after baseline MRI follow-up",

--- a/src/appendices/phenotype.md
+++ b/src/appendices/phenotype.md
@@ -14,14 +14,19 @@ You can make them mandatory during validation by setting the
 [`AdditionalValidation` key](../modality-agnostic-files/dataset-description.md#additional-validation)
 to contain `"Phenotype"` in the `dataset_description.json`.
 
-### 1. Aggregate data across sessions for phenotypic and assessment data
+### 1. Aggregate data across sessions using `"IndexColumns"`
 
-In multi-session datasets, aggregate phenotypic and assessment data across all sessions
+In multi-session datasets,
+aggregate phenotypic and assessment data across all sessions
 into one tabular tab-separated value (TSV) file per measurement tool.
-In order to aggregate, you MUST use the `"IndexColumns"` list field
+In order to aggregate, you MUST use the `"IndexColumns"` list/array field
 in the corresponding JavaScript Object Notation (JSON) sidecar file.
+There are two examples of this usage [below in this appendix](#examples).
 Store each of the TSV and JSON files in the `/phenotype` directory
 using the file-naming template `/phenotype/tool-<ToolName>_phenotype.tsv`.
+Read the [phenotypic and assessment data section](phenotypic-and-assessment-data.md)
+for further explanation of how to use `"IndexColumns"`
+to aggregate longitudinal or multi-session tabular phenotypic data.
 
 ### 2. Always pair tabular data with data dictionaries
 
@@ -65,13 +70,15 @@ all imaging data and tabular phenotypic data MUST have sessions.
 This produces files in which same-participant entries can take up as many rows as needed
 according to the smallest unit of acquisition.
 
-### 5. Use the demographics file for multi-session data
+### 5. Use a demographics file for multi-session data
 
 If there is more than one session for any one participant, then
 it is REQUIRED to provide a demographics file in the `/phenotype` directory
-named as `/phenotype/tool-Demographics_phenotype.tsv`.
+named as `/phenotype/tool-Demographics_phenotype.tsv`
+using the `"IndexColumns"` JSON sidecar field.
 It is RECOMMENDED to store the `age` column for multi-session datasets
-in this demographics file to record participant age at every session separately.
+in this demographics file to record participant age for every session
+on their own rows.
 
 ### 6. Record acquisition time of all sessions with `acq_time`
 

--- a/src/appendices/phenotype.md
+++ b/src/appendices/phenotype.md
@@ -14,20 +14,19 @@ You can make them mandatory during validation by setting the
 [`AdditionalValidation` key](../modality-agnostic-files/dataset-description.md#additional-validation)
 to contain `"Phenotype"` in the `dataset_description.json`.
 
-### 1. Aggregate data across sessions
+### 1. Aggregate data across sessions for phenotypic and assessment data
 
-Aggregate participant information across all sessions into one tabular TSV file per
-measurement or phenotypic assessment and store this file in the `/phenotype` directory.
-Demographic information is a special case and SHOULD be aggregated
-in the `participants.tsv` file at the root level of the dataset.
-It is RECOMMENDED to use the `age` column in the `participants.tsv` file
-to record participant age at every session in longitudinal or multi-session data sets.
+In multi-session datasets, aggregate phenotypic and assessment data across all sessions
+into one tabular tab-separated value (TSV) file per measurement tool.
+In order to aggregate, you MUST use the `"IndexColumns"` list field
+in the corresponding JavaScript Object Notation (JSON) sidecar file.
+Store each of the TSV and JSON files in the `/phenotype` directory
+using the file-naming template `/phenotype/tool-<ToolName>_phenotype.tsv`.
 
 ### 2. Always pair tabular data with data dictionaries
 
 Tabular phenotypic data MUST be prepared as one pair of a tabular file
-in tab-separated value (TSV) format and a corresponding data dictionary
-in JavaScript Object Notation (JSON) format.
+in TSV format and a corresponding data dictionary in JSON format.
 See the [Tabular files section](../common-principles.md#tabular-files) for more information.
 
 ### 3. Add `MeasurementToolMetadata` to each tabular phenotypic measurement tool
@@ -39,22 +38,15 @@ See [`MeasurementToolMetadata` in the glossary](../glossary.md#measurementtoolme
 
 ### 4. Ensure minimal annotation for phenotypic and assessment data
 
-In phenotypic and assessment data, each measurement tool SHOULD have an independent
+In multi-session phenotypic and assessment data,
+each measurement tool SHOULD have an independent
 aggregated data TSV file in which the user collects all subjects, sessions,
-and/or runs of data as one entry per row (with a row defined by
-the smallest unit of acquisition). In other words:
-
--   Each row MUST start with `participant_id`.
-
--   Each TSV file MUST contain a `session_id` column when
-    multiple [sessions](../glossary.md#session-entities)[<sup>1</sup>](#footnotes) are present
-    in the data set.
-
--   If a measurement tool is acquired multiple times within a single session,
-    a `run_id` column MUST be added to disambiguate the separate acquisitions.
-
--   A measurement tool’s acquisition time SHOULD be stored in the `sessions.tsv`
-    file at the root-level of the dataset in the `acq_time` column.
+and/or runs of data as one entry per row
+(with a row defined by the smallest unit of acquisition).
+This also means the user MUST use the `"IndexColumns"` field
+in each JSON sidecar for multi-session data.
+Some common index columns are:
+`participant_id`, `session_id`, `run_id`, and `acq_time`.
 
 <!-- This block generates a columns table.
 The definitions of these fields can be found in
@@ -64,52 +56,28 @@ and a guide for using macros can be found at
 -->
 {{ MACROS___make_columns_table("modality_agnostic.Phenotypes") }}
 
-Furthermore, if you add a `session_id` column to the tabular phenotypic data,
+Furthermore, if you add a `session_id` index column to any tabular phenotypic data,
 you MUST introduce a session directory to the imaging data,
 even if only one imaging session has been created.
 And vice versa, if imaging data has session directories,
 all imaging data and tabular phenotypic data MUST have sessions.
 
-This produces a file in which same-participant entries can take up as many rows as needed
+This produces files in which same-participant entries can take up as many rows as needed
 according to the smallest unit of acquisition.
 
-### 5. Store demographic data in the participants file and instrument data in the phenotype directory
-
-The participants file is for demographic data about the participant,
-including longitudinal information such as `age`.
-The phenotypic and assessment data directory
-is for phenotypic measurement instruments collected about the participants
-such as questionnaires, surveys, and cognitive assessments.
-Create one tabular file for each instrument
-in the phenotypic and assessment data directory.
-
-### 6. Record participant properties in the participants file and session properties in the sessions file
-
-Since the same `participant_id` and `session_id` columns can be used
-similarly in the participants file and the sessions file,
-use the two different files to instead differentiate
-properties of participants versus sessions.
-Properties of participants MAY include things like
-age, sex, race, or household income.
-Properties of sessions MAY include things like
-acquisition time, measurement device properties,
-and indoor or outdoor experimental conditions.
-
-### 7. Use the sessions file at the root-level
+### 5. Use the demographics file for multi-session data
 
 If there is more than one session for any one participant, then
-it is REQUIRED to provide a sessions file at the dataset root,
-even if this file only contains a two-column inventory
-of `participant_id` and `session_id`.
-The `sessions.tsv` file MUST list all sessions for all subjects across
-imaging and tabular phenotypic data. The `sessions.json` file’s
-`session_id` field MUST include `"Levels"` with the description of each `session_id`.
+it is REQUIRED to provide a demographics file in the `/phenotype` directory
+named as `/phenotype/tool-Demographics_phenotype.tsv`.
+It is RECOMMENDED to store the `age` column for multi-session datasets
+in this demographics file to record participant age at every session separately.
 
-### 8. Record acquisition time of all sessions with `acq_time`
+### 6. Record acquisition time of all sessions with `acq_time`
 
 It is RECOMMENDED to store acquisition time[<sup>2</sup>](#footnotes)
 for tabular phenotypic data and store the time of acquisition of each row
-inside a column named `acq_time` in the sessions file.
+inside a column named `acq_time` in the demographics file.
 This is consistent with how acquisition time is recorded for MRI data
 and other time-sensitive measurements (for example systolic blood pressure).
 
@@ -120,7 +88,7 @@ In summary, it is RECOMMENDED to always use the participants file
 and separate files by measurement instrument in
 the phenotypic and assessment data directory,
 since they each collect different information.
-If you use sessions, then the sessions file is also RECOMMENDED.
+If you have multi-session data, then follow the aggregation guidelines above.
 
 ## Examples
 
@@ -137,8 +105,8 @@ A guide for using macros can be found at
 {{ MACROS___make_filetree_example(
    {
    "phenotype": {
-      "measurement_tool.json": "",
-      "measurement_tool.tsv": "",
+      "tool-Measurements_phenotype.json": "",
+      "tool-Measurements_phenotype.tsv": "",
       },
    "sub-01": {
       "anat": {
@@ -149,7 +117,7 @@ A guide for using macros can be found at
    }
 ) }}
 
-Contents of `phenotype/measurement_tool.tsv`
+Contents of `phenotype/tool-Measurements_phenotype.tsv`
 
 ```tsv
 participant_id	measurement_1	measurement_2
@@ -161,10 +129,10 @@ sub-01	value1	value2
 With only one imaging and one phenotypic session each in this example you might want
 to merge both imaging and phenotypic data under one session. But it is more correct to
 have separate sessions for the imaging and phenotypic data, especially if
-the sessions were collected days, weeks, or months apart. You can denote both sessions
-and their acquisition time in the `sessions.tsv` file and have `session_id` `Levels` noted
-in the `sessions.json` sidecar. Below are a CORRECT and an INCORRECT example
-of prepared data following these guidelines.
+the sessions were collected days, weeks, or months apart. You can denote all of
+`participant_id`, `session_id`, and `acq_time` in the `tool-Measurements_phenotype.tsv` file
+and note `session_id` `Levels` in the `tool-Measurements_phenotype.json` sidecar.
+Below are a CORRECT and an INCORRECT example of prepared data following these guidelines.
 
 #### CORRECT
 
@@ -176,11 +144,9 @@ A guide for using macros can be found at
 -->
 {{ MACROS___make_filetree_example(
    {
-   "sessions.json": "",
-   "sessions.tsv": "",
    "phenotype": {
-      "measurement_tool.json": "",
-      "measurement_tool.tsv": "",
+      "tool-Measurements_phenotype.json": "",
+      "tool-Measurements_phenotype.tsv": "",
       },
    "sub-01": {
       "ses-MRI": {
@@ -193,19 +159,42 @@ A guide for using macros can be found at
    }
 ) }}
 
-Contents of `sessions.tsv`
+Contents of `phenotype/tool-Measurements_phenotype.tsv`
 
 ```tsv
-participant_id	session_id	acq_time
-sub-01	ses-pheno	2001-01-01T12:05:00
-sub-01	ses-MRI	2001-03-01T13:14:00
+participant_id	session_id	acq_time	measurement_1	measurement_2
+sub-01	ses-pheno	2001-01-01T12:05:00	value1	value2
+sub-01	ses-MRI	2001-03-01T13:14:00	n/a	n/a
 ```
 
-Contents of `phenotype/measurement_tool.tsv`
+Contents of `phenotype/tool-Measurements_phenotype.json`
 
-```tsv
-participant_id	session_id	measurement_1	measurement_2
-sub-01	ses-pheno	value1	value2
+```json
+{
+    "IndexColumns": [
+        "participant_id",
+        "session_id"
+    ],
+    "participant_id": {
+        "Description": "BIDS participant identifier"
+    },
+    "session_id": {
+        "Description": "BIDS session identifier",
+        "Levels": {
+            "ses-pheno": "Phenotype-only session",
+            "ses-MRI": "MRI-only session"
+        }
+    },
+    "acq_time": {
+        "Description": "When the data acquisition started"
+    },
+    "measurement_1": {
+        "Description": "A first measurement taken at a phenotypic session"
+    },
+    "measurement_2": {
+        "Description": "A second measurement taken at a phenotypic session"
+    }
+}
 ```
 
 #### INCORRECT
@@ -219,8 +208,8 @@ A guide for using macros can be found at
 {{ MACROS___make_filetree_example(
    {
    "phenotype": {
-      "measurement_tool.json": "",
-      "measurement_tool.tsv": "",
+      "tool-Measurements_phenotype.json": "",
+      "tool-Measurements_phenotype.tsv": "",
       },
    "sub-01": {
       "anat": {
@@ -231,15 +220,18 @@ A guide for using macros can be found at
    }
 ) }}
 
-Contents of `phenotype/measurement_tool.tsv`
+Contents of `phenotype/tool-Measurements_phenotype.tsv`
 
 ```tsv
 participant_id	measurement_1	measurement_2
 sub-01	value1	value2
 ```
 
-A session directory **MUST** be present in the participant directory and
-the `session_id` column **MUST** be present in `phenotype/measurement_tool.tsv` as well.
+A session directory MUST be present in the participant's directory and
+the `session_id` column MUST be present
+in `phenotype/tool-Measurements_phenotype.tsv`,
+and the `"IndexColumns"` of `participant_id` and `session_id` MUST be present
+in `phenotype/tool-Measurements_phenotype.json`.
 Sessions must be used consistently for the combination of tabular and
 non-tabular phenotypic data.
 
@@ -258,11 +250,9 @@ A guide for using macros can be found at
 -->
 {{ MACROS___make_filetree_example(
    {
-   "sessions.json": "",
-   "sessions.tsv": "",
    "phenotype": {
-      "measurement_tool.json": "",
-      "measurement_tool.tsv": "",
+      "tool-Measurements_phenotype.json": "",
+      "tool-Measurements_phenotype.tsv": "",
       },
    "sub-01": {
       "ses-MRI1": {
@@ -289,23 +279,14 @@ A guide for using macros can be found at
    }
 ) }}
 
-Contents of `sessions.tsv`
+Contents of `phenotype/tool-Measurements_phenotype.tsv`
 
 ```tsv
-participant_id	session_id	acq_time
-sub-01	ses-MRI1	2001-01-01T11:12:00
-sub-01	ses-MRI2	2001-07-01T13:14:00
-sub-02	ses-MRI1	2001-01-181T15:16:00
-sub-02	ses-pheno	2001-02-20T12:05:00
-```
-
-Contents of `phenotype/measurement_tool.tsv`
-
-```tsv
-participant_id	session_id	measurement_1	measurement_2
-sub-01	ses-MRI1	value1	value2
-sub-02	ses-MRI1	value3	value4
-sub-02	ses-pheno	value5	value6
+participant_id	session_id	acq_time	measurement_1	measurement_2
+sub-01	ses-MRI1	2001-01-01T11:12:00	value1	value2
+sub-01	ses-MRI2	2001-07-01T13:14:00	n/a	n/a
+sub-02	ses-MRI1	2001-01-181T15:16:00	value3	value4
+sub-02	ses-pheno	2001-02-20T12:05:00	value5	value6
 ```
 
 ### 3 participants with 3 different kinds of sessions among them
@@ -322,11 +303,11 @@ A guide for using macros can be found at
    {
    "participants.json": "",
    "participants.tsv": "",
-   "sessions.json": "",
-   "sessions.tsv": "",
    "phenotype": {
-      "survey.json": "",
-      "survey.tsv": "",
+      "tool-Demographics_phenotype.json": "",
+      "tool-Demographics_phenotype.tsv": "",
+      "tool-Survey_phenotype.json": "",
+      "tool-Survey_phenotype.tsv": "",
       },
    "sub-01": {
       "ses-baseline/": "",
@@ -342,37 +323,41 @@ A guide for using macros can be found at
    }
 ) }}
 
-Contents of `participants.tsv`. Participant properties that can change
+Contents of `participants.tsv`.
+Unchanging participant propoerties belong here.
+
+```tsv
+participant_id	sex
+sub-01	M
+sub-02	F
+sub-03	F
+```
+
+Contents of `phenotype/tool-Demographics_phenotype.tsv`.
+Participant properties that can change
 from session to session belong here especially.
 
 ```tsv
-participant_id	session_id	sex	age	gender	race	household_income
-sub-01	ses-baseline	M	10	3	4	5
-sub-01	ses-followupMRI	M	10	3	4	5
-sub-01	ses-interview	M	11	4	4	6
-sub-02	ses-baseline	F	9	1	3	3
-sub-02	ses-interview	F	10	1	7	3
-sub-03	ses-baseline	F	11	2	10	4
-sub-03	ses-followupMRI	F	12	5	10	4
+participant_id	session_id	acq_time	age	gender	race	household_income
+sub-01	ses-baseline	2001-01-01T12:05:00	10	3	4	5
+sub-01	ses-followupMRI	2001-07-01T13:33:00	10	3	4	5
+sub-01	ses-interview	2002-01-01T11:21:00	11	4	4	6
+sub-02	ses-baseline	2001-04-01T11:01:00	9	1	3	3
+sub-02	ses-interview	2002-04-01T14:08:00	10	1	7	3
+sub-03	ses-baseline	2001-09-01T11:45:00	11	2	10	4
+sub-03	ses-followupMRI	2002-03-01T12:17:00	12	5	10	4
 ```
 
-Contents of `sessions.tsv`.
-
-```tsv
-participant_id	session_id	acq_time
-sub-01	ses-baseline	2001-01-01T12:05:00
-sub-01	ses-followupMRI	2001-07-01T13:33:00
-sub-01	ses-interview	2002-01-01T11:21:00
-sub-02	ses-baseline	2001-04-01T11:01:00
-sub-02	ses-interview	2002-04-01T14:08:00
-sub-03	ses-baseline	2001-09-01T11:45:00
-sub-03	ses-followupMRI	2002-03-01T12:17:00
-```
-
-Contents of `sessions.json`. Note how the `session_id` `Levels` are clearly described.
+Partial contents of `phenotype/tool-Demographics_phenotype.json`.
+Note how the `session_id` `Levels` are clearly described
+and how `"IndexColumns"` is present.
 
 ```json
 {
+    "IndexColumns": [
+        "participant_id",
+        "session_id"
+    ],
     "participant_id": {
         "Description": "BIDS participant identifier"
     },
@@ -390,9 +375,10 @@ Contents of `sessions.json`. Note how the `session_id` `Levels` are clearly desc
 }
 ```
 
-Contents of `phenotype/survey.tsv`. Note how `sub-03` does not have
-a row for `ses-interview` because that session was not collected
-and is absent above in the `participants.tsv` and `sessions.tsv` files.
+Contents of `phenotype/tool-Survey_phenotype.tsv`.
+Note how `sub-03` does not have a row for `ses-interview`
+because that session was not collected and is absent above
+in the `phenotype/tool-Demographics_phenotype.tsv` file as well.
 
 ```tsv
 participant_id	session_id	question_1	question_2	question_3

--- a/src/longitudinal-and-multi-site-studies.md
+++ b/src/longitudinal-and-multi-site-studies.md
@@ -109,3 +109,9 @@ underscores are not allowed in subject labels.
 
 In case of studies such as "Traveling Human Phantom" it is possible to incorporate site within session label.
 For example `sub-human1/ses-NUY`, `sub-human1/ses-MIT`, `sub-phantom1/ses-NUY`, `sub-phantom1/ses-MIT` and so on.
+
+## On tabular phenotypic data across sessions
+
+Read the [tabular phenotypic data guidelines appendix](appendices/phenotype.md)
+for an explanation of how to use `"IndexColumns"`
+to aggregate longitudinal or multi-session tabular phenotypic data.

--- a/src/longitudinal-and-multi-site-studies.md
+++ b/src/longitudinal-and-multi-site-studies.md
@@ -113,5 +113,6 @@ For example `sub-human1/ses-NUY`, `sub-human1/ses-MIT`, `sub-phantom1/ses-NUY`, 
 ## On tabular phenotypic data across sessions
 
 Read the [tabular phenotypic data guidelines appendix](appendices/phenotype.md)
+or the [phenotypic and assessment data section](phenotypic-and-assessment-data.md)
 for an explanation of how to use `"IndexColumns"`
 to aggregate longitudinal or multi-session tabular phenotypic data.

--- a/src/modality-agnostic-files/data-summary-files.md
+++ b/src/modality-agnostic-files/data-summary-files.md
@@ -84,13 +84,21 @@ to date of birth.
 }
 ```
 
-It is RECOMMENDED to use the `age` column to record participant age
-at every session in longitudinal or multi-session data sets.
+It is RECOMMENDED to use the `age` column to record participant age.
 This reduces data duplication across tabular data files. The `Units` of `age`
 do not have to be years so long as the units of the age
 are written in `participants.json`.
 Consider participant privacy or study objectives when selecting
 the `Units` of `age` or the accuracy of `age` data.
+
+There are two ways to record `age` in longitudinal or multi-session data sets.
+Choose what makes the most sense for your dataset's expected users.
+The first method is to aggregate into a single file in the phenotypic and assessment data folder
+using the `"IndexColumns"` field in the sidecar JSON.
+Read the [tabular phenotypic data guidelines appendix](../appendices/phenotype.md)
+for further explanation of the demographics file.
+The second method is to segregate `age` into participant's session files.
+Read the [sessions file section](#sessions-file) below for further explanation.
 
 ## Samples file
 

--- a/src/modality-agnostic-files/data-summary-files.md
+++ b/src/modality-agnostic-files/data-summary-files.md
@@ -96,6 +96,7 @@ Choose what makes the most sense for your dataset's expected users.
 The first method is to aggregate into a single file in the phenotypic and assessment data folder
 using the `"IndexColumns"` field in the sidecar JSON.
 Read the [tabular phenotypic data guidelines appendix](../appendices/phenotype.md)
+or the [phenotypic and assessment data section](phenotypic-and-assessment-data.md)
 for an explanation of how to use `"IndexColumns"`
 to aggregate longitudinal or multi-session tabular phenotypic data.
 The second method is to segregate `age` into participant's session files.
@@ -282,6 +283,7 @@ and a guide for using macros can be found at
 ```
 
 Read the [tabular phenotypic data guidelines appendix](../appendices/phenotype.md)
+or the [phenotypic and assessment data section](phenotypic-and-assessment-data.md)
 for an explanation of how to use `"IndexColumns"`
 to aggregate longitudinal or multi-session tabular phenotypic data.
 
@@ -292,14 +294,10 @@ contains `"Phenotype"` in the `dataset_description.json`,
 the following tabular phenotypic data guidelines
 apply to sessions files:
 
--   [6.](../appendices/phenotype.md#6-record-participant-properties-in-the-participants-file-and-session-properties-in-the-sessions-file)
-    Record participant properties in the participants file
-    and session properties in the sessions file
+-   [5.](../appendices/phenotype.md#5-use-a-demographics-file-for-multi-session-data)
+    Use a demographics file for multi-session data
 
--   [7.](../appendices/phenotype.md#7-use-the-sessions-file-at-the-root-level)
-    Use the sessions file at the root-level
-
--   [8.](../appendices/phenotype.md#8-record-acquisition-time-of-all-sessions-with-acq_time)
+-   [6.](../appendices/phenotype.md#6-record-acquisition-time-of-all-sessions-with-acq_time)
     Record acquisition time of all sessions with `acq_time`
 
 To read more about the guidelines for tabular phenotypic data and examples,

--- a/src/modality-agnostic-files/data-summary-files.md
+++ b/src/modality-agnostic-files/data-summary-files.md
@@ -91,12 +91,13 @@ are written in `participants.json`.
 Consider participant privacy or study objectives when selecting
 the `Units` of `age` or the accuracy of `age` data.
 
-There are two ways to record `age` in longitudinal or multi-session data sets.
+There are two methods to record `age` in longitudinal or multi-session data sets.
 Choose what makes the most sense for your dataset's expected users.
 The first method is to aggregate into a single file in the phenotypic and assessment data folder
 using the `"IndexColumns"` field in the sidecar JSON.
 Read the [tabular phenotypic data guidelines appendix](../appendices/phenotype.md)
-for further explanation of the demographics file.
+for an explanation of how to use `"IndexColumns"`
+to aggregate longitudinal or multi-session tabular phenotypic data.
 The second method is to segregate `age` into participant's session files.
 Read the [sessions file section](#sessions-file) below for further explanation.
 
@@ -218,80 +219,7 @@ meg/sub-control01_task-rest_split-02_meg.nii.gz	1877-06-15T12:15:27
 
 ## Sessions file
 
-In case of multiple sessions there is an option of adding an additional
-`sessions.tsv` file describing each session and variables changing between sessions.
-It is RECOMMENDED to provide this as a single file at the root-level of the dataset.
-It is OPTIONAL to instead provide these as separate files at the subject-level of the dataset.
-The intent of the sessions file is to describe the sessions
-in a data set and non-demographic variables changing between sessions.
-Column names in `sessions.tsv` files MUST be different from participant key column names in
-the [participants file](#participants-file).
-
-<!-- This block generates a columns table.
-The definitions of these fields can be found in
-  src/schema/rules/tabular_data/*.yaml
-and a guide for using macros can be found at
- https://github.com/bids-standard/bids-specification/blob/master/macros_doc.md
--->
-{{ MACROS___make_columns_table("modality_agnostic.Sessions") }}
-
-`sessions.json` example:
-
-```JSON
-{
-    "participant_id": {
-        "Description": "Participant identifier"
-    },
-    "session_id": {
-        "Description": "Session identifier for the session",
-        "Levels": {
-            "ses-predrug": "session before drug administration",
-            "ses-postdrug": "session after drug administration",
-            "ses-followup": "follow-up session"
-        }
-    },
-    "acq_time": {
-        "Description": "Acquisition time of the session"
-    },
-    "systolic_blood_pressure": {
-        "Description": "Systolic blood pressure measured at the beginning of the session in mmHg"
-    }
-}
-```
-
-### RECOMMENDED: Root-level sessions file
-
-<!-- This block generates a file tree.
-A guide for using macros can be found at
- https://github.com/bids-standard/bids-specification/blob/master/macros_doc.md
--->
-{{ MACROS___make_filetree_example(
-   {
-   "sessions.tsv": "",
-   "[sessions.json]": "",
-   }
-) }}
-
-Optional: Yes
-
-An aggregated sessions file is RECOMMENDED to be provided at the dataset root.
-If a root-level sessions file is provided, then it MUST begin with
-a `participant_id` column followed immediately after by a `session_id` column.
-
-`sessions.tsv` example:
-
-```tsv
-participant_id	session_id	acq_time	systolic_blood_pressure
-sub-01	ses-predrug	2009-06-15T13:45:30	120
-sub-01	ses-postdrug	2009-06-16T13:45:30	100
-sub-01	ses-followup	2009-06-17T13:45:30	110
-sub-02	ses-predrug	2009-06-22T12:22:05	105
-sub-02	ses-postdrug	2009-06-23T12:22:05	95
-sub-03	ses-postdrug	2009-06-30T14:06:40	115
-sub-03	ses-followup	2009-07-01T14:06:40	120
-```
-
-### OPTIONAL: Participant-level sessions files
+Template:
 
 <!-- This block generates a file tree.
 A guide for using macros can be found at
@@ -308,8 +236,13 @@ A guide for using macros can be found at
 
 Optional: Yes
 
-When one sessions file per participant is used,
-these files MUST include a `session_id` column and describe each session by one and only one row.
+In case of multiple sessions there is an option of adding an additional
+sessions file describing each session and variables changing between sessions.
+Column names in sessions files MUST be different from participant key column names in
+the [participants file](#participants-file).
+
+These files MUST start with a `session_id` column
+and describe each session by one and only one row.
 `sub-<label>/sub-<label>_sessions.tsv` example:
 
 ```tsv
@@ -318,6 +251,39 @@ ses-predrug	2009-06-15T13:45:30	120
 ses-postdrug	2009-06-16T13:45:30	100
 ses-followup	2009-06-17T13:45:30	110
 ```
+
+<!-- This block generates a columns table.
+The definitions of these fields can be found in
+  src/schema/rules/tabular_data/*.yaml
+and a guide for using macros can be found at
+ https://github.com/bids-standard/bids-specification/blob/master/macros_doc.md
+-->
+{{ MACROS___make_columns_table("modality_agnostic.Sessions") }}
+
+`sub-<label>/sub-<label>_sessions.json` example:
+
+```JSON
+{
+    "session_id": {
+        "Description": "Session identifier",
+        "Levels": {
+            "ses-predrug": "session before drug administration",
+            "ses-postdrug": "session after drug administration",
+            "ses-followup": "follow-up session"
+        }
+    },
+    "acq_time": {
+        "Description": "Acquisition time of the session"
+    },
+    "systolic_blood_pressure": {
+        "Description": "Systolic blood pressure measured at the beginning of the session in mmHg"
+    }
+}
+```
+
+Read the [tabular phenotypic data guidelines appendix](../appendices/phenotype.md)
+for an explanation of how to use `"IndexColumns"`
+to aggregate longitudinal or multi-session tabular phenotypic data.
 
 ### Additional validation
 

--- a/src/modality-agnostic-files/phenotypic-and-assessment-data.md
+++ b/src/modality-agnostic-files/phenotypic-and-assessment-data.md
@@ -105,6 +105,9 @@ includes information about the questionnaire,
 and `participant_id`, `session_id`, `adhd_b`, and `adhd_c_dx`
 correspond to individual columns in the TSV data.
 
+For TSV examples, read the
+[tabular phenotypic data guidelines appendix](../appendices/phenotype.md#examples).
+
 In addition to the keys available to describe columns in all tabular files
 (`LongName`, `Description`, `Levels`, `Units`, and `TermURL`) the
 `participants.json` file as well as phenotypic files can also include column
@@ -120,8 +123,8 @@ contains `"Phenotype"` in the `dataset_description.json`,
 the following tabular phenotypic data guidelines
 apply to phenotypic and assessment data.
 
--   [1.](../appendices/phenotype.md#1-aggregate-data-across-sessions)
-    Aggregate data across sessions
+-   [1.](../appendices/phenotype.md#1-aggregate-data-across-sessions-using-indexcolumns)
+    Aggregate data across sessions using `"IndexColumns"`
 
 -   [2.](../appendices/phenotype.md#2-always-pair-tabular-data-with-data-dictionaries)
     Always pair tabular data with data dictionaries
@@ -131,10 +134,6 @@ apply to phenotypic and assessment data.
 
 -   [4.](../appendices/phenotype.md#4-ensure-minimal-annotation-for-phenotypic-and-assessment-data)
     Ensure minimal annotation for phenotypic and assessment data
-
--   [5.](../appendices/phenotype.md#5-store-demographic-data-in-the-participants-file-and-instrument-data-in-the-phenotype-directory)
-    Store demographic data in the participants file
-    and instrument data in the phenotype directory
 
 To read more about the guidelines for tabular phenotypic data and examples,
 see the [tabular phenotypic data guidelines appendix](../appendices/phenotype.md).

--- a/src/modality-agnostic-files/phenotypic-and-assessment-data.md
+++ b/src/modality-agnostic-files/phenotypic-and-assessment-data.md
@@ -100,7 +100,7 @@ As an example, consider the contents of a file called
 Please note in this example
 there MUST be no more than one unique combination of
 the joint indices of `participant_id` and `session_id`.
-Also in this example `MeasurementToolMetadata`
+Also in the above example, `MeasurementToolMetadata`
 includes information about the questionnaire,
 and `participant_id`, `session_id`, `adhd_b`, and `adhd_c_dx`
 correspond to individual columns in the TSV data.

--- a/src/modality-agnostic-files/phenotypic-and-assessment-data.md
+++ b/src/modality-agnostic-files/phenotypic-and-assessment-data.md
@@ -4,8 +4,8 @@ Template:
 
 ```Text
 phenotype/
-    <measurement_tool_name>.tsv
-    <measurement_tool_name>.json
+    [tool-]<MeasurementToolName>[_phenotype].tsv
+    [tool-]<MeasurementToolName>[_phenotype].json
 ```
 
 Optional: Yes
@@ -50,19 +50,35 @@ and a guide for using macros can be found at
 -->
 {{ MACROS___make_metadata_table(
    {
+      "IndexColumns": "OPTIONAL",
       "MeasurementToolMetadata": "OPTIONAL",
       "Derivative": "OPTIONAL",
    }
 ) }}
 
+The `"IndexColumns"` field defines a "joint index".
+This means there MAY be more than one row per `participant_id`,
+but there MUST be no more than one unique combination of
+the joint indices defined in the list among all rows.
+
 As an example, consider the contents of a file called
-`phenotype/acds_adult.json`:
+`phenotype/tool-ACDSAdult_phenotype.json` in a multi-session dataset:
 
 ```JSON
 {
+  "IndexColumns": [
+    "participant_id",
+    "session_id"
+  ],
   "MeasurementToolMetadata": {
     "Description": "Adult ADHD Clinical Diagnostic Scale V1.2",
     "TermURL": "https://www.cognitiveatlas.org/task/id/trm_5586ff878155d"
+  },
+  "participant_id": {
+    "Description": "BIDS participant identifier, of the format sub-<label>"
+  },
+  "session_id": {
+    "Description": "BIDS session identifier, of the format ses-<label>"
   },
   "adhd_b": {
     "Description": "B. CHILDHOOD ONSET OF ADHD (PRIOR TO AGE 7)",
@@ -81,15 +97,19 @@ As an example, consider the contents of a file called
 }
 ```
 
-Please note that in this example `MeasurementToolMetadata` includes information
-about the questionnaire and `adhd_b` and `adhd_c_dx` correspond to individual
-columns.
+Please note in this example
+there MUST be no more than one unique combination of
+the joint indices of `participant_id` and `session_id`.
+Also in this example `MeasurementToolMetadata`
+includes information about the questionnaire,
+and `participant_id`, `session_id`, `adhd_b`, and `adhd_c_dx`
+correspond to individual columns in the TSV data.
 
 In addition to the keys available to describe columns in all tabular files
 (`LongName`, `Description`, `Levels`, `Units`, and `TermURL`) the
 `participants.json` file as well as phenotypic files can also include column
 descriptions with a `Derivative` field that, when set to true, indicates that
-values in the corresponding column is a transformation of values from other
+values in the corresponding column are a transformation of values from other
 columns (for example a summary score based on a subset of items in a
 questionnaire).
 

--- a/src/schema/objects/datatypes.yaml
+++ b/src/schema/objects/datatypes.yaml
@@ -69,7 +69,7 @@ phenotype:
   value: phenotype
   display_name: Phenotype
   description: |
-    Participant level measurement data
+    Participant-level tabular measurement data
     (for example, responses from multiple questionnaires)
     split into individual files separate from `participants.tsv`.
 nirs:

--- a/src/schema/objects/entities.yaml
+++ b/src/schema/objects/entities.yaml
@@ -490,6 +490,13 @@ template:
     [Coordinate Systems Appendix](SPEC_ROOT/appendices/coordinate-systems.md).
   type: string
   format: label
+tool:
+  name: tool
+  display_name: Tabular measurement tool
+  description: |
+    An alphanumeric name for a phenotypic and assessment data tabular file.
+  type: string
+  format: label
 tracer:
   name: trc
   display_name: Tracer
@@ -500,16 +507,6 @@ tracer:
     Therefore, if the `trc-<label>` entity is present in a filename,
     `"TracerName"` MUST be defined in the associated metadata.
     Please note that the `<label>` does not need to match the actual value of the field.
-  type: string
-  format: label
-volume:
-  name: voi
-  display_name: Volume of Interest
-  description: |
-    The `voi-<label>` entity can be used to distinguish acquisitions localized to different regions.
-    The label SHOULD be the name of the body region or part scanned.
-    If used, the fields `"BodyPart"` and `"BodyPartDetails"` MUST be defined in the JSON file.
-    `BodyPartDetailsOntology` is OPTIONAL to also include.
   type: string
   format: label
 tracksys:
@@ -524,5 +521,15 @@ tracksys:
     This entity corresponds to the `"TrackingSystemName"` metadata field in a *_motion.json file.
     `tracksys-<label>` entity is a concise string whereas `"TrackingSystemName"`
     may be longer and more human readable.
+  type: string
+  format: label
+volume:
+  name: voi
+  display_name: Volume of Interest
+  description: |
+    The `voi-<label>` entity can be used to distinguish acquisitions localized to different regions.
+    The label SHOULD be the name of the body region or part scanned.
+    If used, the fields `"BodyPart"` and `"BodyPartDetails"` MUST be defined in the JSON file.
+    `BodyPartDetailsOntology` is OPTIONAL to also include.
   type: string
   format: label

--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -1904,6 +1904,15 @@ Immersion:
     Lens immersion medium. If the file format is OME-TIFF, the value MUST be consistent
     with the `Immersion` OME metadata field.
   type: string
+IndexColumns:
+  name: IndexColumns
+  display_name: Index Columns
+  description: |
+    A list of column names to be used as joint indices in
+    their corresponding tabular phenotypic data file.
+  type: array
+  items:
+    type: string
 InfusionRadioactivity:
   name: InfusionRadioactivity
   display_name: Infusion Radioactivity

--- a/src/schema/objects/suffixes.yaml
+++ b/src/schema/objects/suffixes.yaml
@@ -814,6 +814,11 @@ phasediff:
     unique `phasediff` file.
     For instance, this is a common output for the built-in fieldmap sequence of
     Siemens scanners.
+phenotype:
+  value: phenotype
+  display_name: Tabular phenotypic data
+  description: |
+    A table of data in a tab-separated value (TSV) file.
 photo:
   value: photo
   display_name: Photo File

--- a/src/schema/rules/sidecars/phenotype.yaml
+++ b/src/schema/rules/sidecars/phenotype.yaml
@@ -1,4 +1,11 @@
 ---
+IndexColumns:
+  selectors:
+    - datatype == 'phenotype'
+    - extension == '.tsv'
+  fields:
+    IndexColumns: optional
+
 MeasurementToolMetadata:
   selectors:
     - datatype == 'phenotype'

--- a/src/schema/rules/tabular_data/modality_agnostic.yaml
+++ b/src/schema/rules/tabular_data/modality_agnostic.yaml
@@ -2,7 +2,6 @@
 Participants:
   selectors:
     - path == "/participants.tsv"
-    - '!intersects(dataset.dataset_description.AdditionalValidation, ["Phenotype"])'
   initial_columns:
     - participant_id
   columns:
@@ -19,19 +18,6 @@ Participants:
     HED: optional
   index_columns: [participant_id]
   additional_columns: allowed
-
-Participants__Additional:
-  $ref: rules.tabular_data.modality_agnostic.Participants
-  selectors:
-    - path == "/participants.tsv"
-    - intersects(dataset.dataset_description.AdditionalValidation, ["Phenotype"])
-  columns:
-    participant_id: required
-    group: recommended
-    height: recommended
-    weight: recommended
-    HED: optional
-  additional_columns: allowed_if_defined
 
 Phenotypes:
   selectors:

--- a/src/schema/rules/tabular_data/modality_agnostic.yaml
+++ b/src/schema/rules/tabular_data/modality_agnostic.yaml
@@ -5,10 +5,11 @@ Participants:
     - '!intersects(dataset.dataset_description.AdditionalValidation, ["Phenotype"])'
   initial_columns:
     - participant_id
-    - session_id
   columns:
-    participant_id: required
-    session_id: recommended
+    participant_id:
+      level: required
+      description_addendum: |
+        There MUST be exactly one row for each participant.
     species: recommended
     age: recommended
     sex: recommended
@@ -16,7 +17,7 @@ Participants:
     strain: recommended
     strain_rrid: recommended
     HED: optional
-  index_columns: [participant_id, session_id]
+  index_columns: [participant_id]
   additional_columns: allowed
 
 Participants__Additional:
@@ -26,7 +27,9 @@ Participants__Additional:
     - intersects(dataset.dataset_description.AdditionalValidation, ["Phenotype"])
   columns:
     participant_id: required
-    session_id: recommended
+    group: recommended
+    height: recommended
+    weight: recommended
     HED: optional
   additional_columns: allowed_if_defined
 
@@ -37,35 +40,18 @@ Phenotypes:
     - '!intersects(dataset.dataset_description.AdditionalValidation, ["Phenotype"])'
   initial_columns:
     - participant_id
-    - session_id
-    - run_id
   columns:
     participant_id:
       level: required
-      description_addendum: |
-        Note that data for one participant MAY be represented across multiple rows
-        in case of multiple sessions or runs, and
-        therefore the entry in the `participant_id` column will be repeated.
-    session_id:
-      level: optional
-      description_addendum: |
-        A `session_id` column MUST be added to all tabular files in the phenotype directory
-        as soon as multiple sessions are present in the data set.
-    run_id:
-      level: optional
-      level_addendum: required if there are multiple runs within any session
-      description_addendum: |
-        A chronological `run` number is used when
-        a measurement tool or assessment described by a tabular file
-        was repeated within a session.
     HED: optional
-  index_columns: [participant_id, session_id, run_id]
+  index_columns: [participant_id]
   additional_columns: allowed
 
 Phenotypes__Additional:
   $ref: rules.tabular_data.modality_agnostic.Phenotypes
   selectors:
     - datatype == 'phenotype'
+    - suffix == 'phenotype'
     - intersects(dataset.dataset_description.AdditionalValidation, ["Phenotype"])
   additional_columns: allowed_if_defined
 
@@ -103,17 +89,16 @@ Sessions:
     - extension == ".tsv"
     - '!intersects(dataset.dataset_description.AdditionalValidation, ["Phenotype"])'
   initial_columns:
-    - participant_id
     - session_id
-    - run_id
   columns:
-    participant_id: optional
-    session_id: required
-    run_id: optional
+    session_id:
+      level: required
+      description_addendum: |
+        There MUST be exactly one row for each session.
     acq_time__sessions: optional
     pathology: recommended
     HED: optional
-  index_columns: [participant_id, session_id, run_id]
+  index_columns: [session_id]
   additional_columns: allowed
 
 Sessions__Additional:


### PR DESCRIPTION
After a few conversations with Dr. Yaroslav O. Halchenko, we decided to provide the `"IndexColumns"`field to phenotypic and assessment data in order to allow aggregation in a more structured and less BIDS-overriding way. This PR is to integrate the first draft changes of this rewrite.